### PR TITLE
Removes Resolver Warning on Compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,10 @@ members = [
   "libs/*",
   "bin"
 ]
+resolver = "2"
 
 [profile.release]
 lto = true
 opt-level = 3
+
+

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -18,3 +18,6 @@ search_engine = { path = "../libs/search-engine" }
 task_runners = { path = "../libs/task-runners" }
 tokio = { version = "1.17.0", features = ["fs", "macros", "rt-multi-thread"], default-features = false }
 www = { path = "../libs/www" }
+
+[workspace]
+resolver = "2"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -19,5 +19,5 @@ task_runners = { path = "../libs/task-runners" }
 tokio = { version = "1.17.0", features = ["fs", "macros", "rt-multi-thread"], default-features = false }
 www = { path = "../libs/www" }
 
-[workspace]
-resolver = "2"
+
+


### PR DESCRIPTION
Edition 2021 evidently implies the use of resolver "2" whereas resolver "1" is the default used on my system at least (NixOS, which is its own unique beast). This quick fix removes the warning, doesn't negatively affect the build process and merged into my fork without reporting any problems, so here it is for upstream. 

Its just 2 lines in the `bin/Cargo.toml` file, nothing huge but it helped me get the thing to build so maybe others will appreciate it as well. Awesome project, great work. 